### PR TITLE
'gulp dist' now generates a service-worker for dist folder rather tha…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ app/app.iml
 
 #generated SW
 app/service-worker.js
+dist/service-worker.js

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "path": "^0.12.7",
     "run-sequence": "^1.2.2",
     "sw-precache": "^4.3.0",
-    "node-sass": "^4.2.0",
-    "yargs": "^6.6.0"
+    "node-sass": "^4.2.0"
   }
 }


### PR DESCRIPTION
…n copying it over from app, preventing ServiceWorker from freaking out because it cant find files (misses the .min. in file name)